### PR TITLE
Added swipe member variable finalPosition.

### DIFF
--- a/CCGestureRecognizer/CCSwipeGestureRecognizer.cpp
+++ b/CCGestureRecognizer/CCSwipeGestureRecognizer.cpp
@@ -111,7 +111,8 @@ void CCSwipeGestureRecognizer::ccTouchEnded(CCTouch * pTouch, CCEvent * pEvent)
         CCSwipe * swipe = CCSwipe::create();
         swipe->direction = (CCSwipeGestureRecognizerDirection)dir;
         swipe->location = initialPosition;
-        
+       	swipe->finalLocation = finalPosition;
+
         gestureRecognized(swipe);
         if (cancelsTouchesInView) stopTouchesPropagation(createSetWithTouch(pTouch), pEvent); //cancel touch over other views
     }

--- a/CCGestureRecognizer/CCSwipeGestureRecognizer.h
+++ b/CCGestureRecognizer/CCSwipeGestureRecognizer.h
@@ -43,6 +43,7 @@ public:
     CREATE_FUNC(CCSwipe);
     CCSwipeGestureRecognizerDirection direction;
     cocos2d::CCPoint location;
+    cocos2d::CCPoint finalLocation;
 };
 
 class CCSwipeGestureRecognizer : public CCGestureRecognizer


### PR DESCRIPTION
In my game, I found it useful to have a final position for the swipe (along with the initial position). I have tested this by drawing sprites where the initial and final touches are located; it seems to work very well.
