### PR TITLE
Check the angle between the last touch and the vertical/horizontal axis starting from the origin point

### DIFF
--- a/CCGestureRecognizer/CCSwipeGestureRecognizer.cpp
+++ b/CCGestureRecognizer/CCSwipeGestureRecognizer.cpp
@@ -36,32 +36,43 @@ CCSwipeGestureRecognizer::~CCSwipeGestureRecognizer()
     
 }
 
-bool CCSwipeGestureRecognizer::checkSwipeDirection(CCPoint p1, CCPoint p2, int & dir)
+bool CCSwipeGestureRecognizer::checkSwipeDirection(CCPoint initial, CCPoint final, int & dir)
 {
-    bool right = p2.x-p1.x>=kSwipeMinDistance;
-    bool left = p1.x-p2.x>=kSwipeMinDistance;
-    bool down = p1.y-p2.y>=kSwipeMinDistance;
-    bool up = p2.y-p1.y>=kSwipeMinDistance;
+    bool right = final.x-initial.x>=kSwipeMinDistance;
+    bool left = initial.x-final.x>=kSwipeMinDistance;
+    bool down = initial.y-final.y>=kSwipeMinDistance;
+    bool up = final.y-initial.y>=kSwipeMinDistance;
     
-    if (right) {
+    // we need to determine the angle between the starting point and the end point
+    // to do this we'll use the formula
+    // sin(angle) = opposite / hypothenuse
+    // therefore
+    // asin(opposite / hypothenuse) = angle (in radians)
+    float hyp = distanceBetweenPoints(initial, final);
+    float vOpposite = distanceBetweenPoints(ccp(initial.x, final.y), final);
+    float hOpposite = distanceBetweenPoints(ccp( final.x, initial.y), final);
+    float horizontalAngle = CC_RADIANS_TO_DEGREES(asinf(hOpposite / hyp));
+    float verticalAngle = CC_RADIANS_TO_DEGREES(asinf(vOpposite / hyp));
+    
+    if (right && horizontalAngle < kSwipeMaxAngle) {
         if ((direction & kSwipeGestureRecognizerDirectionRight) == kSwipeGestureRecognizerDirectionRight) {
             dir = kSwipeGestureRecognizerDirectionRight;
             return true;
         }
     }
-    else if (left) {
+    else if (left && horizontalAngle < kSwipeMaxAngle) {
         if ((direction & kSwipeGestureRecognizerDirectionLeft) == kSwipeGestureRecognizerDirectionLeft) {
             dir = kSwipeGestureRecognizerDirectionLeft;
             return true;
         }
     }
-    else if (up) {
+    else if (up && verticalAngle < kSwipeMaxAngle) {
         if ((direction & kSwipeGestureRecognizerDirectionUp) == kSwipeGestureRecognizerDirectionUp) {
             dir = kSwipeGestureRecognizerDirectionUp;
             return true;
         }
     }
-    else if (down) {
+    else if (down && verticalAngle < kSwipeMaxAngle) {
         if ((direction & kSwipeGestureRecognizerDirectionDown) == kSwipeGestureRecognizerDirectionDown) {
             dir = kSwipeGestureRecognizerDirectionDown;
             return true;
@@ -107,7 +118,11 @@ void CCSwipeGestureRecognizer::ccTouchEnded(CCTouch * pTouch, CCEvent * pEvent)
     //check that maximum duration hasn't been reached
     //check if the direction of the swipe is correct
     int dir = 0;
-    if (distance>=kSwipeMinDistance && duration<=kSwipeMaxDuration && checkSwipeDirection(initialPosition,finalPosition,dir)) {
+    bool minDistanceReached = distance>=kSwipeMinDistance;
+    bool maxDurationNotReached = duration<=kSwipeMaxDuration;
+    bool swipeDirectionIsCorrect = checkSwipeDirection(initialPosition,finalPosition,dir);
+    
+    if (minDistanceReached && maxDurationNotReached && swipeDirectionIsCorrect) {
         CCSwipe * swipe = CCSwipe::create();
         swipe->direction = (CCSwipeGestureRecognizerDirection)dir;
         swipe->location = initialPosition;

--- a/CCGestureRecognizer/CCSwipeGestureRecognizer.h
+++ b/CCGestureRecognizer/CCSwipeGestureRecognizer.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 
 #define kSwipeMaxDuration 300
 #define kSwipeMinDistance 60
+#define kSwipeMaxAngle    30
 
 typedef enum {
     kSwipeGestureRecognizerDirectionRight = 1 << 0,


### PR DESCRIPTION
Swipe detection is not working properly when the swipes are angled, especially upwards or downwards. The user's finger might go to the left or to the right just enough that the validation code in checkSwipeDirection accepts it for a side swipe, although it is obvious that it was a vertical swipe.

To mitigate this I added an angle check so a vertical swipe that goes to the side will not be taken as a side swipe unless the angle between the last touch and the horizontal axis is smaller than kSwipeMaxAngle(=30) degrees.
